### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/PythonChicken123/masterchicken/security/code-scanning/10](https://github.com/PythonChicken123/masterchicken/security/code-scanning/10)

In general, the fix is to define an explicit `permissions` block that grants only the minimal required permissions to the `GITHUB_TOKEN`. For this workflow, the steps only need to read the repository contents (for `actions/checkout`) and do not interact with PRs, issues, packages, or other GitHub resources. The safest minimal scope is therefore `contents: read`.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root (top level), so it applies to all jobs, right after the `on:` block and before `jobs:`. This ensures the `build` job’s `GITHUB_TOKEN` is restricted to `contents: read` while preserving all existing behavior. No additional imports, methods, or other definitions are required, since this is purely a YAML configuration change in `.github/workflows/python-package.yml`.

Concretely: edit `.github/workflows/python-package.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` section (lines 6–10) and the `jobs:` section (line 12).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add a top-level permissions block to the python-package workflow to limit GITHUB_TOKEN to read-only repository contents.